### PR TITLE
[ME-1610] Network Discoverer + Example

### DIFF
--- a/__examples__/network_oneoff/main.go
+++ b/__examples__/network_oneoff/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/borderzero/discovery"
+	"github.com/borderzero/discovery/discoverers"
+	"github.com/borderzero/discovery/engines"
+)
+
+func main() {
+	ctx := context.Background()
+
+	engine := engines.NewOneOffEngine(
+		engines.OneOffEngineOptionWithDiscoverers(
+			discoverers.NewNaiveNetworkDiscoverer( /* ... opts ... */ ),
+		),
+	)
+
+	results := make(chan *discovery.Result, 10)
+
+	go engine.Run(ctx, results)
+
+	for result := range results {
+		byt, err := json.Marshal(result)
+		if err != nil {
+			fmt.Println(fmt.Sprintf("[ERROR] failed to json encode result: %w", err))
+		}
+		fmt.Println(string(byt))
+	}
+}

--- a/discoverers/discoverer_naive_network.go
+++ b/discoverers/discoverer_naive_network.go
@@ -1,0 +1,391 @@
+package discoverers
+
+// FIXME: needs rate limiting options
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/borderzero/discovery"
+)
+
+const (
+	defaultNaiveNetworkDiscovererDiscovererId = "naive_network_discoverer"
+	defaultNaiveNetworkDiscovererScanTimeout  = time.Second * 120
+)
+
+var (
+	defaultNaiveNetworkDiscovererTargets = []string{
+		"192.168.1.0/24",
+	}
+
+	defaultNaiveNetworkDiscovererPorts = []string{
+		"22",   // default ssh port
+		"80",   // default http port
+		"443",  // default https port
+		"3306", // default mysql port
+		"5432", // default postgresql port
+		"8080", // common http port
+		"8443", // common https port
+	}
+
+	mysqlBannerCanaries = []string{
+		"mariadb", // MariaDB is a fork of MySQL
+		"caching_sha2_password",
+		"mysql_native_password",
+		"mysql_clear_password",
+		"sha256_password",
+		"5.7.", // for MySQL 5.7.x
+		"8.0.", // for MySQL 8.0.x
+		"10.",  // for MariaDB 10.x.x
+	}
+
+	sshBannerCanaries = []string{
+		"ssh",      // SSH v2, OpenSSH, LibSSH, etc...
+		"dropbear", // Dropbear server
+		"lsh",      // lsh server
+	}
+)
+
+// NaiveNetworkDiscoverer represents a discoverer for network-reachable resources
+// with a very rudimentary check using TCP probes. This check can (and will) give
+// false positives or negatives. For a more thorough service detection, you would
+// need a more comprehensive set of checks.
+// Nmap for example uses a combination of probes and a large database of well known
+// service banners to identify the service running on a particular port.
+type NaiveNetworkDiscoverer struct {
+	discovererId string
+	scanTimeout  time.Duration
+	targets      []string
+	ports        []string
+}
+
+// ensure NaiveNetworkDiscoverer implements discovery.Discoverer at compile-time.
+var _ discovery.Discoverer = (*NaiveNetworkDiscoverer)(nil)
+
+// NaiveNetworkDiscovererOption represents a configuration option for a NaiveNetworkDiscoverer.
+type NaiveNetworkDiscovererOption func(*NaiveNetworkDiscoverer)
+
+// WithNaiveNetworkDiscovererDiscovererId is the NaiveNetworkDiscovererOption to set a non default discoverer id.
+func WithNaiveNetworkDiscovererDiscovererId(discovererId string) NaiveNetworkDiscovererOption {
+	return func(nd *NaiveNetworkDiscoverer) {
+		nd.discovererId = discovererId
+	}
+}
+
+// WithNaiveNetworkDiscovererScanTimeout is the NaiveNetworkDiscovererOption
+// to set a non default timeout for scanning the network.
+func WithNaiveNetworkDiscovererScanTimeout(timeout time.Duration) NaiveNetworkDiscovererOption {
+	return func(nd *NaiveNetworkDiscoverer) {
+		nd.scanTimeout = timeout
+	}
+}
+
+// WithNaiveNetworkDiscovererTargets is the NaiveNetworkDiscovererOption
+// to set non default targets (IPs or DNS names) for discovery.
+func WithNaiveNetworkDiscovererTargets(targets ...string) NaiveNetworkDiscovererOption {
+	return func(nd *NaiveNetworkDiscoverer) {
+		nd.targets = targets
+	}
+}
+
+// WithNaiveNetworkDiscovererPorts is the NaiveNetworkDiscovererOption
+// to set non default target ports for discovery.
+func WithNaiveNetworkDiscovererPorts(ports ...string) NaiveNetworkDiscovererOption {
+	return func(nd *NaiveNetworkDiscoverer) {
+		nd.ports = ports
+	}
+}
+
+// NewNaiveNetworkDiscoverer returns a new NaiveNetworkDiscoverer, initialized with the given options.
+func NewNaiveNetworkDiscoverer(opts ...NaiveNetworkDiscovererOption) *NaiveNetworkDiscoverer {
+	nd := &NaiveNetworkDiscoverer{
+		discovererId: defaultNaiveNetworkDiscovererDiscovererId,
+		scanTimeout:  defaultNaiveNetworkDiscovererScanTimeout,
+		targets:      defaultNaiveNetworkDiscovererTargets,
+		ports:        defaultNaiveNetworkDiscovererPorts,
+	}
+	for _, opt := range opts {
+		opt(nd)
+	}
+	return nd
+}
+
+// Discover runs the NaiveNetworkDiscoverer.
+func (nd *NaiveNetworkDiscoverer) Discover(ctx context.Context) *discovery.Result {
+	result := discovery.NewResult(nd.discovererId)
+	defer result.Done()
+
+	for _, target := range nd.targets {
+		ips, err := targetToIps(target)
+		if err != nil {
+			result.AddError(fmt.Errorf("failed to get IPs for target: %v", err))
+			continue
+		}
+
+		var wg sync.WaitGroup
+		for _, ip := range ips {
+			for _, port := range nd.ports {
+				wg.Add(1)
+				go func(ip, port string) {
+					defer wg.Done()
+					svc, ok := scanPort(ctx, ip, port)
+					if ok {
+						// best effort dns name lookup
+						hostnames, _ := net.LookupAddr(ip)
+						switch svc {
+						case "http":
+							result.AddResources(discovery.Resource{
+								ResourceType: discovery.ResourceTypeNetworkHttpServer,
+								NetworkHttpServerDetails: &discovery.NetworkHttpServerDetails{
+									NetworkBaseDetails: discovery.NetworkBaseDetails{
+										Addresses: []string{ip},
+										HostNames: hostnames,
+										Port:      port,
+									},
+								},
+							})
+						case "https":
+							result.AddResources(discovery.Resource{
+								ResourceType: discovery.ResourceTypeNetworkHttpsServer,
+								NetworkHttpsServerDetails: &discovery.NetworkHttpsServerDetails{
+									NetworkBaseDetails: discovery.NetworkBaseDetails{
+										Addresses: []string{ip},
+										HostNames: hostnames,
+										Port:      port,
+									},
+								},
+							})
+						case "mysql":
+							result.AddResources(discovery.Resource{
+								ResourceType: discovery.ResourceTypeNetworkMysqlServer,
+								NetworkMysqlServerDetails: &discovery.NetworkMysqlServerDetails{
+									NetworkBaseDetails: discovery.NetworkBaseDetails{
+										Addresses: []string{ip},
+										HostNames: hostnames,
+										Port:      port,
+									},
+								},
+							})
+						case "postgresql":
+							result.AddResources(discovery.Resource{
+								ResourceType: discovery.ResourceTypeNetworkPostgresqlServer,
+								NetworkPostgresqlServerDetails: &discovery.NetworkPostgresqlServerDetails{
+									NetworkBaseDetails: discovery.NetworkBaseDetails{
+										Addresses: []string{ip},
+										HostNames: hostnames,
+										Port:      port,
+									},
+								},
+							})
+						case "ssh":
+							result.AddResources(discovery.Resource{
+								ResourceType: discovery.ResourceTypeNetworkSshServer,
+								NetworkSshServerDetails: &discovery.NetworkSshServerDetails{
+									NetworkBaseDetails: discovery.NetworkBaseDetails{
+										Addresses: []string{ip},
+										HostNames: hostnames,
+										Port:      port,
+									},
+								},
+							})
+						}
+					}
+				}(ip, port)
+			}
+		}
+		wg.Wait()
+	}
+	return result
+}
+
+func checkService(ip string, port string) string {
+
+	for _, scheme := range []string{"https", "http"} {
+		client := &http.Client{Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}}
+		req, _ := http.NewRequest(
+			http.MethodGet,
+			fmt.Sprintf("%s://%s:%s", scheme, ip, port),
+			nil,
+		)
+		resp, err := client.Do(req)
+		if err != nil {
+			continue
+		}
+		defer resp.Body.Close()
+
+		return scheme
+	}
+
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, port), 10*time.Millisecond)
+	if err != nil {
+		return "unknown"
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(time.Millisecond * 1000))
+
+	resp := make([]byte, 1024)
+	_, err = conn.Read(resp)
+	if err != nil {
+		// postgresql normally returns a binary handshake... can't check for that
+		// so we assume if something's listening on port 5432, its a postgresql server
+		if port == "5432" {
+			return "postgresql"
+		}
+		return "unknown"
+	}
+
+	response := strings.ToLower(string(resp))
+	for _, canary := range mysqlBannerCanaries {
+		if strings.Contains(response, canary) {
+			return "mysql"
+		}
+	}
+	for _, canary := range sshBannerCanaries {
+		if strings.Contains(response, canary) {
+			return "ssh"
+		}
+	}
+
+	// postgresql normally returns a binary handshake... can't check for that
+	// so we assume if something's listening on port 5432, its a postgresql server
+	if port == "5432" {
+		return "postgresql"
+	}
+
+	return "unknown"
+}
+
+func scanPort(ctx context.Context, ip, port string) (string, bool) {
+	conn, err := (&net.Dialer{Timeout: time.Millisecond * 1000}).DialContext(
+		ctx,
+		"tcp",
+		fmt.Sprintf("%s:%s", ip, port),
+	)
+	if err != nil {
+		return "", false
+	}
+	conn.Close()
+
+	service := checkService(ip, port)
+	if service != "unknown" {
+		return service, true
+	}
+	return "", false
+}
+
+func targetToIps(target string) ([]string, error) {
+	if isCidr(target) {
+		ips, err := cidrToIPs(target)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get IPs from CIDR: %v", err)
+		}
+		return ips, nil
+	}
+	if isIpRange(target) {
+		ips, err := rangeToIPs(target)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get IPs from range: %v", err)
+		}
+		return ips, nil
+	}
+	if isIP(target) {
+		return []string{target}, nil
+	}
+	if isHostname(target) {
+		ips, err := hostnameToIps(target)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get IPs from hostname: %v", err)
+		}
+		return ips, nil
+	}
+	return nil, fmt.Errorf("target \"%s\" is not a valid CIDR, IP range, IP, nor hostname", target)
+}
+
+func isIP(target string) bool {
+	return regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`).MatchString(target)
+}
+
+func isIpRange(target string) bool {
+	return regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}-(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`).MatchString(target)
+}
+
+func isCidr(target string) bool {
+	return regexp.MustCompile(`^(?:[0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}$`).MatchString(target)
+}
+
+func isHostname(target string) bool {
+	return regexp.MustCompile(`^[a-zA-Z0-9-.]+$`).MatchString(target)
+}
+
+func hostnameToIps(hostname string) ([]string, error) {
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	ipStrings := make([]string, len(ips))
+	for i, ip := range ips {
+		ipStrings[i] = ip.String()
+	}
+	return ipStrings, nil
+}
+
+func rangeToIPs(ipRange string) ([]string, error) {
+	parts := strings.Split(ipRange, "-")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid range")
+	}
+
+	startIP := net.ParseIP(parts[0])
+	endIP := net.ParseIP(parts[1])
+	if startIP == nil || endIP == nil {
+		return nil, fmt.Errorf("invalid IP address")
+	}
+
+	ips := make([]string, 0)
+	for ip := startIP; !ip.Equal(endIP); incIP(ip) {
+		ips = append(ips, ip.String())
+	}
+	ips = append(ips, endIP.String()) // Include the endIP in the list
+
+	return ips, nil
+}
+
+func cidrToIPs(cidr string) ([]string, error) {
+	ip, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, err
+	}
+
+	var ips []string
+	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); incIP(ip) {
+		ips = append(ips, ip.String())
+	}
+
+	// remove network and broadcast addresses
+	if len(ips) > 2 {
+		ips = ips[1 : len(ips)-1]
+	}
+
+	return ips, nil
+}
+
+func incIP(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}

--- a/discoverers/discoverer_nmap_network.go
+++ b/discoverers/discoverer_nmap_network.go
@@ -1,0 +1,247 @@
+package discoverers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Ullaakut/nmap"
+	"github.com/borderzero/border0-go/lib/types/slice"
+	"github.com/borderzero/discovery"
+)
+
+const (
+	defaultNmapNetworkDiscovererDiscovererId = "nmap_network_discoverer"
+	defaultNmapNetworkDiscovererScanTimeout  = time.Second * 120
+
+	nmapDiscoveredPortServiceNameHttp       = "http"
+	nmapDiscoveredPortServiceNameHttps      = "https"
+	nmapDiscoveredPortServiceNameSsh        = "ssh"
+	nmapDiscoveredPortServiceNameMysql      = "mysql"
+	nmapDiscoveredPortServiceNamePostgresql = "postgresql"
+)
+
+var (
+	defaultNmapNetworkDiscovererTargets = []string{
+		"192.168.1.0/24",
+	}
+	defaultNmapNetworkDiscovererPorts = []string{
+		"22",   // default ssh port
+		"80",   // default http port
+		"443",  // default https port
+		"3306", // default mysql port
+		"5432", // default postgresql port
+		"8080", // common http port
+		"8443", // common https port
+	}
+)
+
+// NmapNetworkDiscoverer represents a discoverer for network-reachable
+// resources using a library that relies on the nmap binary being present.
+// Note that running the NmapNetworkDiscoverer without the nmap binary being
+// available will result in failure to discover resources with this Discoverer.
+type NmapNetworkDiscoverer struct {
+	discovererId string
+	scanTimeout  time.Duration
+	nmapOpts     []func(*nmap.Scanner)
+	targets      []string
+	ports        []string
+}
+
+// ensure NmapNetworkDiscoverer implements discovery.Discoverer at compile-time.
+var _ discovery.Discoverer = (*NmapNetworkDiscoverer)(nil)
+
+// NmapNetworkDiscovererOption represents a configuration option for an NmapNetworkDiscoverer.
+type NmapNetworkDiscovererOption func(*NmapNetworkDiscoverer)
+
+// WithNmapNetworkDiscovererDiscovererId is the NmapNetworkDiscovererOption to set a non default discoverer id.
+func WithNmapNetworkDiscovererDiscovererId(discovererId string) NmapNetworkDiscovererOption {
+	return func(nd *NmapNetworkDiscoverer) {
+		nd.discovererId = discovererId
+	}
+}
+
+// WithNmapNetworkDiscovererScanTimeout is the NmapNetworkDiscovererOption
+// to set a non default timeout for scanning the network.
+func WithNmapNetworkDiscovererScanTimeout(timeout time.Duration) NmapNetworkDiscovererOption {
+	return func(nd *NmapNetworkDiscoverer) {
+		nd.scanTimeout = timeout
+	}
+}
+
+// WithNmapNetworkDiscovererTargets is the NmapNetworkDiscovererOption
+// to set non default targets (IPs or DNS names) for discovery.
+func WithNmapNetworkDiscovererTargets(targets ...string) NmapNetworkDiscovererOption {
+	return func(nd *NmapNetworkDiscoverer) {
+		nd.targets = targets
+	}
+}
+
+// WithNmapNetworkDiscovererPorts is the NmapNetworkDiscovererOption
+// to set non default target ports for discovery.
+func WithNmapNetworkDiscovererPorts(ports ...string) NmapNetworkDiscovererOption {
+	return func(nd *NmapNetworkDiscoverer) {
+		nd.ports = ports
+	}
+}
+
+// WithNmapNetworkDiscovererMinScanDelay is the NmapNetworkDiscovererOption
+// to set non default min delay for discovery (time between probes).
+func WithNmapNetworkDiscovererMinScanDelay(delay time.Duration) NmapNetworkDiscovererOption {
+	return func(nd *NmapNetworkDiscoverer) {
+		nd.nmapOpts = append(nd.nmapOpts, nmap.WithScanDelay(delay))
+	}
+}
+
+// WithNmapNetworkDiscovererMaxScanDelay is the NmapNetworkDiscovererOption
+// to set non default max delay for discovery (time between probes).
+func WithNmapNetworkDiscovererMaxScanDelay(delay time.Duration) NmapNetworkDiscovererOption {
+	return func(nd *NmapNetworkDiscoverer) {
+		nd.nmapOpts = append(nd.nmapOpts, nmap.WithMaxScanDelay(delay))
+	}
+}
+
+// WithNmapNetworkDiscovererMinScanRate is the NmapNetworkDiscovererOption
+// to set non default min rate for discovery (packets per second).
+func WithNmapNetworkDiscovererMinScanRate(packetsPerSecond int) NmapNetworkDiscovererOption {
+	return func(nd *NmapNetworkDiscoverer) {
+		nd.nmapOpts = append(nd.nmapOpts, nmap.WithMinRate(packetsPerSecond))
+	}
+}
+
+// WithNmapNetworkDiscovererMaxScanRate is the NmapNetworkDiscovererOption
+// to set non default max rate for discovery (packets per second).
+func WithNmapNetworkDiscovererMaxScanRate(packetsPerSecond int) NmapNetworkDiscovererOption {
+	return func(nd *NmapNetworkDiscoverer) {
+		nd.nmapOpts = append(nd.nmapOpts, nmap.WithMaxRate(packetsPerSecond))
+	}
+}
+
+// NewNmapNetworkDiscoverer returns a new NmapNetworkDiscoverer, initialized with the given options.
+func NewNmapNetworkDiscoverer(opts ...NmapNetworkDiscovererOption) *NmapNetworkDiscoverer {
+	nd := &NmapNetworkDiscoverer{
+		discovererId: defaultNmapNetworkDiscovererDiscovererId,
+		scanTimeout:  defaultNmapNetworkDiscovererScanTimeout,
+		targets:      defaultNmapNetworkDiscovererTargets,
+		ports:        defaultNmapNetworkDiscovererPorts,
+	}
+	for _, opt := range opts {
+		opt(nd)
+	}
+	return nd
+}
+
+// Discover runs the NmapNetworkDiscoverer.
+func (nd *NmapNetworkDiscoverer) Discover(ctx context.Context) *discovery.Result {
+	result := discovery.NewResult(nd.discovererId)
+	defer result.Done()
+
+	scanCtx, cancel := context.WithTimeout(ctx, nd.scanTimeout)
+	defer cancel()
+
+	// build options
+	opts := append(
+		[]func(*nmap.Scanner){
+			nmap.WithContext(scanCtx),
+			nmap.WithTargets(nd.targets...),
+			nmap.WithPorts(nd.ports...),
+		},
+		nd.nmapOpts...,
+	)
+
+	// equivalent to `nmap -p ${PORTS} ${TARGETS[@]} ${OPT_FLAGS[@]}`
+	scanner, err := nmap.NewScanner(opts...)
+	if err != nil {
+		result.AddError(fmt.Errorf("unable to create nmap scanner: %v", err))
+		return result
+	}
+
+	// FIXME: support warnings in discoverer (second return argument of scanner.Run())?
+	scannerResults, _, err := scanner.Run()
+	if err != nil {
+		result.AddError(fmt.Errorf("unable to run nmap scan: %v", err))
+		return result
+	}
+
+	// process results
+	for _, host := range scannerResults.Hosts {
+		// filter out hosts with no ports or no addresses
+		if len(host.Ports) == 0 || len(host.Addresses) == 0 {
+			continue
+		}
+		for _, port := range host.Ports {
+			// filter out closed ports
+			if port.State.String() == "closed" || port.State.String() == "filtered" {
+				continue
+			}
+			// filter out ports that are not TCP ports
+			// as they are currently useless...
+			if port.Protocol != "tcp" {
+				continue
+			}
+
+			networkBaseDetails := discovery.NetworkBaseDetails{
+				Addresses: slice.Transform(host.Addresses, func(a nmap.Address) string { return a.Addr }),
+				HostNames: slice.Transform(host.Hostnames, func(h nmap.Hostname) string { return h.String() }),
+				Port:      fmt.Sprintf("%d", port.ID),
+			}
+
+			// http
+			if port.Service.Name == nmapDiscoveredPortServiceNameHttp {
+				result.AddResources(discovery.Resource{
+					ResourceType: discovery.ResourceTypeNetworkHttpServer,
+					NetworkHttpServerDetails: &discovery.NetworkHttpServerDetails{
+						NetworkBaseDetails: networkBaseDetails,
+					},
+				})
+				continue
+			}
+
+			// https
+			if port.Service.Name == nmapDiscoveredPortServiceNameHttps {
+				result.AddResources(discovery.Resource{
+					ResourceType: discovery.ResourceTypeNetworkHttpsServer,
+					NetworkHttpsServerDetails: &discovery.NetworkHttpsServerDetails{
+						NetworkBaseDetails: networkBaseDetails,
+					},
+				})
+				continue
+			}
+
+			// mysql
+			if port.Service.Name == nmapDiscoveredPortServiceNameMysql {
+				result.AddResources(discovery.Resource{
+					ResourceType: discovery.ResourceTypeNetworkMysqlServer,
+					NetworkMysqlServerDetails: &discovery.NetworkMysqlServerDetails{
+						NetworkBaseDetails: networkBaseDetails,
+					},
+				})
+				continue
+			}
+
+			// postgresql
+			if port.Service.Name == nmapDiscoveredPortServiceNamePostgresql {
+				result.AddResources(discovery.Resource{
+					ResourceType: discovery.ResourceTypeNetworkPostgresqlServer,
+					NetworkPostgresqlServerDetails: &discovery.NetworkPostgresqlServerDetails{
+						NetworkBaseDetails: networkBaseDetails,
+					},
+				})
+				continue
+			}
+
+			// ssh
+			if port.Service.Name == nmapDiscoveredPortServiceNameSsh {
+				result.AddResources(discovery.Resource{
+					ResourceType: discovery.ResourceTypeNetworkSshServer,
+					NetworkSshServerDetails: &discovery.NetworkSshServerDetails{
+						NetworkBaseDetails: networkBaseDetails,
+					},
+				})
+				continue
+			}
+		}
+	}
+
+	return result
+}

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/borderzero/discovery
 go 1.20
 
 require (
+	github.com/Ullaakut/nmap v2.0.2+incompatible
 	github.com/aws/aws-sdk-go-v2 v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.99.0
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/rds v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.6
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
+	github.com/borderzero/border0-go v0.1.4
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Ullaakut/nmap v2.0.2+incompatible h1:edw45QpSQBQ2B/Hqfg86Bt5rrK79tp/fAcqIHyNSdQs=
+github.com/Ullaakut/nmap v2.0.2+incompatible/go.mod h1:fkC066hwfcoKwlI7DS2ARTggSVtBTZYCjVH1TzuTMaQ=
 github.com/aws/aws-sdk-go-v2 v1.18.0/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
 github.com/aws/aws-sdk-go-v2 v1.18.1 h1:+tefE750oAb7ZQGzla6bLkOwfcQCEtC5y2RqoqCeqKo=
 github.com/aws/aws-sdk-go-v2 v1.18.1/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
@@ -22,8 +24,10 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.19.2 h1:XFJ2Z6sNUUcAz9poj+245DMkrHE4
 github.com/aws/aws-sdk-go-v2/service/sts v1.19.2/go.mod h1:dp0yLPsLBOi++WTxzCjA/oZqi6NPIhoR+uF7GeMU9eg=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/borderzero/border0-go v0.1.4 h1:f+RXRBp1fs7EXCJC00usexEql7Yi8KeyZ7aAh53zcwg=
+github.com/borderzero/border0-go v0.1.4/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -33,8 +37,10 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/resource.go
+++ b/resource.go
@@ -13,11 +13,20 @@ const (
 	// ResourceTypeAwsSsmTarget is the resource type for AWS SSM targets.
 	ResourceTypeAwsSsmTarget = "aws_ssm_target"
 
-	// ResourceTypeNetworkSshServer is the resource type for network-reachable SSH servers.
-	ResourceTypeNetworkSshServer = "network_ssh_server"
-
 	// ResourceTypeNetworkHttpServer is the resource type for network-reachable HTTP servers.
 	ResourceTypeNetworkHttpServer = "network_http_server"
+
+	// ResourceTypeNetworkHttpsServer is the resource type for network-reachable HTTPS servers.
+	ResourceTypeNetworkHttpsServer = "network_https_server"
+
+	// ResourceTypeNetworkMysqlServer is the resource type for network-reachable MySQL servers.
+	ResourceTypeNetworkMysqlServer = "network_mysql_server"
+
+	// ResourceTypeNetworkPostgresqlServer is the resource type for network-reachable PostgreSQL servers.
+	ResourceTypeNetworkPostgresqlServer = "network_postgresql_server"
+
+	// ResourceTypeNetworkSshServer is the resource type for network-reachable SSH servers.
+	ResourceTypeNetworkSshServer = "network_ssh_server"
 )
 
 // AwsBaseDetails represents the details of a discovered generic AWS resource.
@@ -25,6 +34,13 @@ type AwsBaseDetails struct {
 	AwsAccountId string `json:"aws_account_id"`
 	AwsRegion    string `json:"aws_region"`
 	AwsArn       string `json:"aws_arn"`
+}
+
+// NetworkBaseDetails represents the details of a discovered generic service on the network.
+type NetworkBaseDetails struct {
+	Addresses []string `json:"addresses"`
+	HostNames []string `json:"hostnames,omitempty"`
+	Port      string   `json:"port"`
 }
 
 // AwsEc2InstanceDetails represents the details of a discovered AWS EC2 instance.
@@ -86,14 +102,59 @@ type AwsSsmTargetDetails struct {
 	// add any new fields as needed here
 }
 
+// NetworkHttpServerDetails represents the details
+// of a discovered HTTP server on the network.
+type NetworkHttpServerDetails struct {
+	NetworkBaseDetails // extends
+
+	// add any new fields as needed here
+}
+
+// NetworkHttpsServerDetails represents the details
+// of a discovered HTTPS server on the network.
+type NetworkHttpsServerDetails struct {
+	NetworkBaseDetails // extends
+
+	// add any new fields as needed here
+}
+
+// NetworkMysqlServerDetails represents the details
+// of a discovered MySQL server on the network.
+type NetworkMysqlServerDetails struct {
+	NetworkBaseDetails // extends
+
+	// add any new fields as needed here
+}
+
+// NetworkPostgresqlServerDetails represents the details
+// of a discovered PostgreSQL server on the network.
+type NetworkPostgresqlServerDetails struct {
+	NetworkBaseDetails // extends
+
+	// add any new fields as needed here
+}
+
+// NetworkSshServerDetails represents the details
+// of a discovered SSH server on the network.
+type NetworkSshServerDetails struct {
+	NetworkBaseDetails // extends
+
+	// add any new fields as needed here
+}
+
 // Resource represents a generic discovered resource.
 type Resource struct {
 	ResourceType string `json:"resource_type"`
 
-	AwsEc2InstanceDetails *AwsEc2InstanceDetails `json:"aws_ec2_instance_details,omitempty"`
-	AwsEcsClusterDetails  *AwsEcsClusterDetails  `json:"aws_ecs_cluster_details,omitempty"`
-	AwsRdsInstanceDetails *AwsRdsInstanceDetails `json:"aws_rds_instance_details,omitempty"`
-	AwsSsmTargetDetails   *AwsSsmTargetDetails   `json:"aws_ssm_target_details,omitempty"`
+	AwsEc2InstanceDetails          *AwsEc2InstanceDetails          `json:"aws_ec2_instance_details,omitempty"`
+	AwsEcsClusterDetails           *AwsEcsClusterDetails           `json:"aws_ecs_cluster_details,omitempty"`
+	AwsRdsInstanceDetails          *AwsRdsInstanceDetails          `json:"aws_rds_instance_details,omitempty"`
+	AwsSsmTargetDetails            *AwsSsmTargetDetails            `json:"aws_ssm_target_details,omitempty"`
+	NetworkHttpServerDetails       *NetworkHttpServerDetails       `json:"network_http_server_details,omitempty"`
+	NetworkHttpsServerDetails      *NetworkHttpsServerDetails      `json:"network_https_server_details,omitempty"`
+	NetworkMysqlServerDetails      *NetworkMysqlServerDetails      `json:"network_mysql_server_details,omitempty"`
+	NetworkPostgresqlServerDetails *NetworkPostgresqlServerDetails `json:"network_postgresql_server_details,omitempty"`
+	NetworkSshServerDetails        *NetworkSshServerDetails        `json:"network_ssh_server_details,omitempty"`
 
 	// add any new resource details here
 }


### PR DESCRIPTION
## [[ME-1610](https://mysocket.atlassian.net/browse/ME-1610)] Network Discoverer + Example

- Adds `NmapNetworkDiscoverer`
- Adds `NaiveNetworkDiscoverer`

Part of https://mysocket.atlassian.net/browse/ME-1610

### Example

```
19:39 $ go run __examples__/network_oneoff/main.go  | jq
{
  "resources": [
    {
      "resource_type": "network_http_server",
      "network_http_server_details": {
        "addresses": [
          "192.168.1.101"
        ],
        "port": "8080"
      }
    },
    {
      "resource_type": "network_mysql_server",
      "network_mysql_server_details": {
        "addresses": [
          "192.168.1.101"
        ],
        "port": "3306"
      }
    },
    {
      "resource_type": "network_http_server",
      "network_http_server_details": {
        "addresses": [
          "192.168.1.31"
        ],
        "port": "8080"
      }
    },
    {
      "resource_type": "network_http_server",
      "network_http_server_details": {
        "addresses": [
          "192.168.1.254"
        ],
        "port": "80"
      }
    },
    {
      "resource_type": "network_http_server",
      "network_http_server_details": {
        "addresses": [
          "192.168.1.254"
        ],
        "port": "443"
      }
    }
  ],
  "errors": [],
  "metadata": {
    "discoverer_id": "naive_network_discoverer",
    "started_at": "2023-06-24T19:40:45.712925-07:00",
    "ended_at": "2023-06-24T19:40:46.740046-07:00"
  }
}
```

[ME-1610]: https://mysocket.atlassian.net/browse/ME-1610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ