### PR TITLE
[ME-1662] Add state filtering options to EC2 discoverer

### DIFF
--- a/__examples__/aws_oneoff/main.go
+++ b/__examples__/aws_oneoff/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	"github.com/borderzero/discovery"
 	"github.com/borderzero/discovery/discoverers"
@@ -23,7 +24,13 @@ func main() {
 
 	engine := engines.NewOneOffEngine(
 		engines.OneOffEngineOptionWithDiscoverers(
-			discoverers.NewAwsEc2Discoverer(cfg),
+			discoverers.NewAwsEc2Discoverer(
+				cfg,
+				discoverers.WithAwsEc2DiscovererIncludedInstanceStates(
+					types.InstanceStateNamePending,
+					types.InstanceStateNameRunning,
+				),
+			),
 			discoverers.NewAwsEcsDiscoverer(cfg),
 			discoverers.NewAwsRdsDiscoverer(cfg),
 			discoverers.NewAwsSsmDiscoverer(cfg),

--- a/resource.go
+++ b/resource.go
@@ -59,11 +59,13 @@ type AwsEc2InstanceDetails struct {
 	ImageId          string `json:"ami_id"`
 	VpcId            string `json:"vpc_id"`
 	SubnetId         string `json:"subnet_id"`
+	AvailabilityZone string `json:"availability_zone"`
 	PrivateDnsName   string `json:"private_dns_name"`
 	PrivateIpAddress string `json:"private_ip_address"`
 	PublicDnsName    string `json:"public_dns_name"`
 	PublicIpAddress  string `json:"public_ip_address"`
 	InstanceType     string `json:"instance_type"`
+	InstanceState    string `json:"instance_state"`
 
 	// add any new fields as needed here
 }


### PR DESCRIPTION
## [[ME-1662](https://mysocket.atlassian.net/browse/ME-1662)] Add state filtering options to EC2 discoverer

- Adds a new option to the ec2 discoverer to set the values of instance state that you want the discoverer to pay attention to.
- Adds availability zone and instance state to EC2 discovered resource type.

Part of https://mysocket.atlassian.net/browse/ME-1662

[ME-1662]: https://mysocket.atlassian.net/browse/ME-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ