### PR TITLE
[ME-1662] Filtering Options for AWS Targets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.6
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
-	github.com/borderzero/border0-go v0.1.4
+	github.com/borderzero/border0-go v0.1.6
 	github.com/docker/docker v24.0.2+incompatible
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3
 	k8s.io/client-go v0.27.3

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/borderzero/border0-go v0.1.4 h1:f+RXRBp1fs7EXCJC00usexEql7Yi8KeyZ7aAh53zcwg=
 github.com/borderzero/border0-go v0.1.4/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
+github.com/borderzero/border0-go v0.1.6 h1:B8a1L4UB2eskPr7Utm8JLKbwwytETc7PsOUk4YPcBSs=
+github.com/borderzero/border0-go v0.1.6/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -253,8 +255,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/resource.go
+++ b/resource.go
@@ -76,10 +76,11 @@ type AwsEcsClusterDetails struct {
 
 	Tags map[string]string `json:"tags"`
 
-	ClusterName string   `json:"cluster_name"`
-	Services    []string `json:"services"`
-	Tasks       []string `json:"tasks"`
-	Containers  []string `json:"containers"`
+	ClusterName   string   `json:"cluster_name"`
+	ClusterStatus string   `json:"cluster_status"`
+	Services      []string `json:"services"`
+	Tasks         []string `json:"tasks"`
+	Containers    []string `json:"containers"`
 
 	// add any new fields as needed here
 }
@@ -90,7 +91,8 @@ type AwsRdsInstanceDetails struct {
 
 	Tags map[string]string `json:"tags"`
 
-	DBInstanceIdentifier string `json:"db_instance_identifier"`
+	DbInstanceIdentifier string `json:"db_instance_identifier"`
+	DbInstanceStatus     string `json:"db_instance_status"`
 	Engine               string `json:"engine"`
 	EngineVersion        string `json:"engine_version"`
 	VpcId                string `json:"vpc_id"`
@@ -106,6 +108,7 @@ type AwsSsmTargetDetails struct {
 	AwsBaseDetails // extends
 
 	InstanceId string `json:"instance_id"`
+	PingStatus string `json:"ping_status"`
 
 	// add any new fields as needed here
 }

--- a/utils/tags.go
+++ b/utils/tags.go
@@ -1,0 +1,25 @@
+package utils
+
+// TagMatchesFilter returns true if a given key-value
+// pair matches a given filter of key-value options.
+func TagMatchesFilter(
+	key string,
+	value string,
+	filter map[string][]string,
+) bool {
+	for filterKey, filterValues := range filter {
+		if key == filterKey {
+			// we interpret empty filter values
+			// as "match any value of the key"
+			if len(filterValues) == 0 {
+				return true
+			}
+			for _, filterValue := range filterValues {
+				if value == filterValue {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## [[ME-1662](https://mysocket.atlassian.net/browse/ME-1662)] Filtering Options for AWS Targets

- Adds options to filter aws ecs and rds targets by aws resource tags. (ec2 already done before)
- Adds options to filter aws ecs, rds, ssm targets by tags and state/status.

[ME-1662]: https://mysocket.atlassian.net/browse/ME-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ