### PR TITLE
[ME-1662] Fixes Minor Discovery Bugs

### DIFF
--- a/discoverers/discoverer_aws_ecs.go
+++ b/discoverers/discoverer_aws_ecs.go
@@ -117,7 +117,10 @@ func (ecsd *AwsEcsDiscoverer) Discover(ctx context.Context) *discovery.Result {
 	}
 	// TODO: new context with timeout for describe clusters
 	// TODO: use paginator
-	describeClustersOutput, err := ecsClient.DescribeClusters(ctx, &ecs.DescribeClustersInput{Clusters: listClustersOutput.ClusterArns})
+	describeClustersOutput, err := ecsClient.DescribeClusters(ctx, &ecs.DescribeClustersInput{
+		Clusters: listClustersOutput.ClusterArns,
+		Include:  []types.ClusterField{types.ClusterFieldTags},
+	})
 	if err != nil {
 		result.AddError(fmt.Errorf("failed to describe ecs clusters: %w", err))
 		return result

--- a/discoverers/discoverer_aws_rds.go
+++ b/discoverers/discoverer_aws_rds.go
@@ -3,12 +3,14 @@ package discoverers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/borderzero/border0-go/lib/types/set"
+	"github.com/borderzero/border0-go/lib/types/slice"
 	"github.com/borderzero/discovery"
 	"github.com/borderzero/discovery/utils"
 )
@@ -19,7 +21,7 @@ const (
 )
 
 var (
-	defaultAwsRdsDiscovererIncludedInstanceStatuses = set.New("Creating", "Starting", "Available", "Maintenance", "Mofifying")
+	defaultAwsRdsDiscovererIncludedInstanceStatuses = set.New("creating", "backing-up", "starting", "available", "maintenance", "modifying")
 )
 
 // AwsRdsDiscoverer represents a discoverer for AWS RDS resources.
@@ -58,7 +60,8 @@ func WithAwsRdsDiscovererGetAccountIdTimeout(timeout time.Duration) AwsRdsDiscov
 // to set a non default list of statuses for instances to include in results.
 func WithAwsRdsDiscovererIncludedInstanceStatuses(statuses ...string) AwsRdsDiscovererOption {
 	return func(rdsd *AwsRdsDiscoverer) {
-		rdsd.includedInstanceStatuses = set.New(statuses...)
+		lowercased := slice.Transform(statuses, func(s string) string { return strings.ToLower(s) })
+		rdsd.includedInstanceStatuses = set.New(lowercased...)
 	}
 }
 

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.19.2 h1:XFJ2Z6sNUUcAz9poj+245DMkrHE4
 github.com/aws/aws-sdk-go-v2/service/sts v1.19.2/go.mod h1:dp0yLPsLBOi++WTxzCjA/oZqi6NPIhoR+uF7GeMU9eg=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
-github.com/borderzero/border0-go v0.1.4 h1:f+RXRBp1fs7EXCJC00usexEql7Yi8KeyZ7aAh53zcwg=
-github.com/borderzero/border0-go v0.1.4/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/borderzero/border0-go v0.1.6 h1:B8a1L4UB2eskPr7Utm8JLKbwwytETc7PsOUk4YPcBSs=
 github.com/borderzero/border0-go v0.1.6/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=


### PR DESCRIPTION
[[ME-1662](https://mysocket.atlassian.net/browse/ME-1662)] Fixes Minor Discovery Bugs

- Lowercases all rds instance states (because the AWS API returns the values lowercased)
- Include tags in the additional fields to include setting for the ECS describe clusters input

Part of https://mysocket.atlassian.net/browse/ME-1662

[ME-1662]: https://mysocket.atlassian.net/browse/ME-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ