### PR TITLE
[ME-1667] Filtering options for K8s Pods

### DIFF
--- a/__examples__/k8s_oneoff/main.go
+++ b/__examples__/k8s_oneoff/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/borderzero/discovery"
+	"github.com/borderzero/discovery/discoverers"
+	"github.com/borderzero/discovery/engines"
+)
+
+func main() {
+	ctx := context.Background()
+
+	engine := engines.NewOneOffEngine(
+		engines.OneOffEngineOptionWithDiscoverers(
+			discoverers.NewKubernetesDiscoverer( /* opts */ ),
+		),
+	)
+
+	results := make(chan *discovery.Result, 10)
+
+	go engine.Run(ctx, results)
+
+	for result := range results {
+		byt, err := json.Marshal(result)
+		if err != nil {
+			fmt.Println(fmt.Sprintf("[ERROR] failed to json encode result: %w", err))
+		}
+		fmt.Println(string(byt))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.6
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
-	github.com/borderzero/border0-go v0.1.6
+	github.com/borderzero/border0-go v0.1.7
 	github.com/docker/docker v24.0.2+incompatible
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.19.2 h1:XFJ2Z6sNUUcAz9poj+245DMkrHE4
 github.com/aws/aws-sdk-go-v2/service/sts v1.19.2/go.mod h1:dp0yLPsLBOi++WTxzCjA/oZqi6NPIhoR+uF7GeMU9eg=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
-github.com/borderzero/border0-go v0.1.6 h1:B8a1L4UB2eskPr7Utm8JLKbwwytETc7PsOUk4YPcBSs=
-github.com/borderzero/border0-go v0.1.6/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
+github.com/borderzero/border0-go v0.1.7 h1:3BUtvpOpfF8RDS0Swn2GtVg/jPjCRCrn8OtMwLDrISA=
+github.com/borderzero/border0-go v0.1.7/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=


### PR DESCRIPTION
## [[ME-1667](https://mysocket.atlassian.net/browse/ME-1667)] Filtering options for K8s Pods

- Adds the missing options to the kubernetes discovery plugin (filter by status and inclusion/exclusion labels)
- Adds example for kubernetes discovery
- Fixes namespace and kubeconfig defaults


[ME-1667]: https://mysocket.atlassian.net/browse/ME-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ