### PR TITLE
[ME-1667] Discover K8s Services (not pods)

### DIFF
--- a/__examples__/k8s_oneoff/main.go
+++ b/__examples__/k8s_oneoff/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/borderzero/discovery"
 	"github.com/borderzero/discovery/discoverers"
@@ -15,7 +16,9 @@ func main() {
 
 	engine := engines.NewOneOffEngine(
 		engines.OneOffEngineOptionWithDiscoverers(
-			discoverers.NewKubernetesDiscoverer( /* opts */ ),
+			discoverers.NewKubernetesDiscoverer(
+				discoverers.WithKubernetesDiscovererKubeconfigPath(fmt.Sprintf("%s/.kube/config", os.Getenv("HOME"))),
+			),
 		),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.36.6
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
-	github.com/borderzero/border0-go v0.1.7
+	github.com/borderzero/border0-go v0.1.8
 	github.com/docker/docker v24.0.2+incompatible
 	k8s.io/api v0.27.3
 	k8s.io/apimachinery v0.27.3

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.19.2 h1:XFJ2Z6sNUUcAz9poj+245DMkrHE4
 github.com/aws/aws-sdk-go-v2/service/sts v1.19.2/go.mod h1:dp0yLPsLBOi++WTxzCjA/oZqi6NPIhoR+uF7GeMU9eg=
 github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
-github.com/borderzero/border0-go v0.1.7 h1:3BUtvpOpfF8RDS0Swn2GtVg/jPjCRCrn8OtMwLDrISA=
-github.com/borderzero/border0-go v0.1.7/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
+github.com/borderzero/border0-go v0.1.8 h1:NjX6egDqXTEjJtEXanF0K10z9GOszFwOvUGHoweBDYg=
+github.com/borderzero/border0-go v0.1.8/go.mod h1:A4NGE3GI2f5NMJcWRuNDCTY6UBegTw4F2l1Q4wdULGY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=

--- a/resource.go
+++ b/resource.go
@@ -13,8 +13,8 @@ const (
 	// ResourceTypeAwsSsmTarget is the resource type for AWS SSM targets.
 	ResourceTypeAwsSsmTarget = "aws_ssm_target"
 
-	// ResourceTypeKubernetesPod is the resource type for kubernetes pods.
-	ResourceTypeKubernetesPod = "kubernetes_pod"
+	// ResourceTypeKubernetesService is the resource type for kubernetes services.
+	ResourceTypeKubernetesService = "kubernetes_service"
 
 	// ResourceTypeLocalDockerContainer is the resource type for containers managed by the local Docker daemon.
 	ResourceTypeLocalDockerContainer = "local_docker_container"
@@ -113,24 +113,29 @@ type AwsSsmTargetDetails struct {
 	// add any new fields as needed here
 }
 
-// KubernetesContainerDetails represents the details of a discovered kubernetes container.
-type KubernetesContainerDetails struct {
-	Name  string `json:"name"`
-	Image string `json:"image"`
-
-	// add any new fields as needed here
+// KubernetesServicePort represents the details of a port for a kubernetes service.
+type KubernetesServicePort struct {
+	Name        string  `json:"name,omitempty"`
+	Protocol    string  `json:"protocol,omitempty"`
+	AppProtocol *string `json:"app_protocol,omitempty"`
+	Port        int32   `json:"port"`
+	TargetPort  string  `json:"target_port,omitempty"`
+	NodePort    int32   `json:"node_port,omitempty"`
 }
 
-// KubernetesPodDetails represents the details of a discovered kubernetes pod.
-type KubernetesPodDetails struct {
-	Namespace   string                       `json:"namespace"`
-	PodName     string                       `json:"pod_name"`
-	PodIP       string                       `json:"pod_ip"`
-	NodeName    string                       `json:"node_name"`
-	Status      string                       `json:"status"`
-	Containers  []KubernetesContainerDetails `json:"containers"`
-	Labels      map[string]string            `json:"labels"`
-	Annotations map[string]string            `json:"annotations"`
+// KubernetesServiceDetails represents the details of a discovered kubernetes service.
+type KubernetesServiceDetails struct {
+	Namespace      string                  `json:"namespace"`
+	Name           string                  `json:"name"`
+	Uid            string                  `json:"uid"`
+	ServiceType    string                  `json:"service_type"`
+	ExternalName   string                  `json:"external_name,omitempty"`
+	LoadBalancerIp string                  `json:"load_balancer_ip,omitempty"`
+	ClusterIp      string                  `json:"cluster_ip"`
+	ClusterIps     []string                `json:"cluster_ips"`
+	Ports          []KubernetesServicePort `json:"ports"`
+	Labels         map[string]string       `json:"labels"`
+	Annotations    map[string]string       `json:"annotations"`
 
 	// add any new fields as needed here
 }
@@ -196,7 +201,7 @@ type Resource struct {
 	AwsEcsClusterDetails           *AwsEcsClusterDetails           `json:"aws_ecs_cluster_details,omitempty"`
 	AwsRdsInstanceDetails          *AwsRdsInstanceDetails          `json:"aws_rds_instance_details,omitempty"`
 	AwsSsmTargetDetails            *AwsSsmTargetDetails            `json:"aws_ssm_target_details,omitempty"`
-	KubernetesPodDetails           *KubernetesPodDetails           `json:"kubernetes_pod_details,omitempty"`
+	KubernetesServiceDetails       *KubernetesServiceDetails       `json:"kubernetes_service_details,omitempty"`
 	LocalDockerContainerDetails    *LocalDockerContainerDetails    `json:"local_docker_container_details,omitempty"`
 	NetworkHttpServerDetails       *NetworkHttpServerDetails       `json:"network_http_server_details,omitempty"`
 	NetworkHttpsServerDetails      *NetworkHttpsServerDetails      `json:"network_https_server_details,omitempty"`


### PR DESCRIPTION
[[ME-1667](https://mysocket.atlassian.net/browse/ME-1667)] Discover K8s Services (not pods)

We decided we should discover k8s services (not pods)

### example

```
✔ ~/go/src/github.com/borderzero/discovery [ME-1667_service_not_pod_discovery_k8s|…1]
16:16 $ go run __examples__/k8s_oneoff/main.go | jq
{
  "resources": [
    {
      "resource_type": "kubernetes_service",
      "kubernetes_service_details": {
        "namespace": "default",
        "name": "kubernetes",
        "uid": "fed0f026-464c-4fd4-8c17-82230cddf49a",
        "service_type": "ClusterIP",
        "cluster_ip": "10.96.0.1",
        "cluster_ips": [
          "10.96.0.1"
        ],
        "ports": [
          {
            "name": "https",
            "protocol": "TCP",
            "port": 443,
            "target_port": "6443"
          }
        ],
        "labels": {
          "component": "apiserver",
          "provider": "kubernetes"
        },
        "annotations": {}
      }
    }
  ],
  "errors": [],
  "metadata": {
    "discoverer_id": "kubernetes_discoverer",
    "started_at": "2023-07-07T16:17:32.688077-07:00",
    "ended_at": "2023-07-07T16:17:32.707025-07:00"
  }
}
```

[ME-1667]: https://mysocket.atlassian.net/browse/ME-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ