### PR TITLE
[ME-1679] ECS Service Discoverer

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -4,8 +4,8 @@ const (
 	// ResourceTypeAwsEc2Instance is the resource type for AWS EC2 instances.
 	ResourceTypeAwsEc2Instance = "aws_ec2_instance"
 
-	// ResourceTypeAwsEcsCluster is the resource type for AWS ECS clusters.
-	ResourceTypeAwsEcsCluster = "aws_ecs_cluster"
+	// ResourceTypeAwsEcsService is the resource type for AWS ECS services.
+	ResourceTypeAwsEcsService = "aws_ecs_service"
 
 	// ResourceTypeAwsRdsInstnace is the resource type for AWS RDS instances.
 	ResourceTypeAwsRdsInstance = "aws_rds_instance"
@@ -84,17 +84,16 @@ type AwsEc2InstanceDetails struct {
 	// add any new fields as needed here
 }
 
-// AwsEcsClusterDetails represents the details of a discovered AWS ECS cluster.
-type AwsEcsClusterDetails struct {
+// AwsEcsServiceDetails represents the details of a discovered AWS ECS service.
+type AwsEcsServiceDetails struct {
 	AwsBaseDetails // extends
 
 	Tags map[string]string `json:"tags"`
 
-	ClusterName   string   `json:"cluster_name"`
-	ClusterStatus string   `json:"cluster_status"`
-	Services      []string `json:"services"`
-	Tasks         []string `json:"tasks"`
-	Containers    []string `json:"containers"`
+	ServiceName          string `json:"service_name"`
+	ClusterArn           string `json:"cluster_arn"`
+	TaskDefinition       string `json:"task_definition"`
+	EnableExecuteCommand bool   `json:"enable_execute_command"`
 
 	// add any new fields as needed here
 }
@@ -212,7 +211,7 @@ type Resource struct {
 	ResourceType string `json:"resource_type"`
 
 	AwsEc2InstanceDetails          *AwsEc2InstanceDetails          `json:"aws_ec2_instance_details,omitempty"`
-	AwsEcsClusterDetails           *AwsEcsClusterDetails           `json:"aws_ecs_cluster_details,omitempty"`
+	AwsEcsServiceDetails           *AwsEcsServiceDetails           `json:"aws_ecs_service_details,omitempty"`
 	AwsRdsInstanceDetails          *AwsRdsInstanceDetails          `json:"aws_rds_instance_details,omitempty"`
 	AwsSsmTargetDetails            *AwsSsmTargetDetails            `json:"aws_ssm_target_details,omitempty"`
 	KubernetesServiceDetails       *KubernetesServiceDetails       `json:"kubernetes_service_details,omitempty"`


### PR DESCRIPTION
## [[ME-1679](https://mysocket.atlassian.net/browse/ME-1679)] ECS Service Discoverer

Modifies ECS discoverer to discover services, not clusters.

The reasoning behind this is that clusters are just analogous to kubernetes clusters -- dont mean anything other than a grouping of services, but ecs services more accurately represent something useful in the context of border0 sockets/services (e.g. how to connect to them - they share LBs and network config + tell us whether exec is enabled or not).

### Example output:

```
{
  "resources": [
    {
      "resource_type": "aws_ecs_service",
      "aws_ecs_service_details": {
        "aws_account_id": "[HIDDEN_ACCT_ID]",
        "aws_region": "us-east-1",
        "aws_arn": "arn:aws:ecs:us-east-1:[HIDDEN_ACCT_ID]:service/andree-cluster/testapp-service",
        "tags": {
          "K": "V"
        },
        "service_name": "testapp-service",
        "cluster_arn": "arn:aws:ecs:us-east-1:[HIDDEN_ACCT_ID]:cluster/andree-cluster",
        "task_definition": "arn:aws:ecs:us-east-1:[HIDDEN_ACCT_ID]:task-definition/testapp-task:8",
        "enable_execute_command": true
      }
    }
  ],
  "metadata": {
    "discoverer_id": "aws_ecs_discoverer",
    "started_at": "2023-07-08T09:15:51.384945-07:00",
    "ended_at": "2023-07-08T09:15:53.058578-07:00"
  },
  "errors": [],
  "warnings": []
}
```


[ME-1667]: https://mysocket.atlassian.net/browse/ME-1667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ME-1679]: https://mysocket.atlassian.net/browse/ME-1679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ