### PR TITLE
[ME-1673] Fix Typo In Docker Opts

### DIFF
--- a/discoverers/discoverer_docker.go
+++ b/discoverers/discoverer_docker.go
@@ -44,9 +44,9 @@ func WithDockerDiscovererListContainersTimeout(timeout time.Duration) DockerDisc
 	return func(dd *DockerDiscoverer) { dd.containerListTimeout = timeout }
 }
 
-// WithDockerDiscovererInclusionInstanceTags is the DockerDiscovererOption
+// WithDockerDiscovererInclusionContainerLabels is the DockerDiscovererOption
 // to set the inclusion labels filter for containers to include in results.
-func WithDockerDiscovererInclusionInstanceTags(labels map[string][]string) DockerDiscovererOption {
+func WithDockerDiscovererInclusionContainerLabels(labels map[string][]string) DockerDiscovererOption {
 	return func(dd *DockerDiscoverer) { dd.inclusionContainerLabels = labels }
 }
 


### PR DESCRIPTION
## [[ME-1673](https://mysocket.atlassian.net/browse/ME-1673)] Fix Typo In Docker Opts

[ME-1673]: https://mysocket.atlassian.net/browse/ME-1673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ