### PR TITLE
[ME-1700] Typo in AWS Account ID utility fn

### DIFF
--- a/utils/aws_account_id.go
+++ b/utils/aws_account_id.go
@@ -24,7 +24,7 @@ func AwsAccountIdFromConfig(
 
 	getCallerIdentityOutput, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if err != nil {
-		return "", fmt.Errorf("failed to AWS account ID via the AWS STS API: %w", err)
+		return "", fmt.Errorf("failed to get AWS account ID via the AWS STS API: %w", err)
 	}
 
 	awsAccountId := aws.ToString(getCallerIdentityOutput.Account)


### PR DESCRIPTION
## [[ME-1700](https://mysocket.atlassian.net/browse/ME-1700)] Typo in AWS Account ID utility fn

Just a typo

[ME-1700]: https://mysocket.atlassian.net/browse/ME-1700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ