### PR TITLE
[ME-3242] Account for IPv6 Addresses Everywhere

### DIFF
--- a/discoverers/discoverer_aws_ec2.go
+++ b/discoverers/discoverer_aws_ec2.go
@@ -3,6 +3,7 @@ package discoverers
 import (
 	"context"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -406,7 +407,7 @@ func (ec2d *AwsEc2Discoverer) reachabilityCheck(
 
 	for _, ip := range ips {
 		for _, port := range ec2d.networkReachabilityCheckPorts.Slice() {
-			reachable := addressReachable(ctx, fmt.Sprintf("%s:%s", ip, port))
+			reachable := addressReachable(ctx, net.JoinHostPort(ip, port))
 			if reachable {
 				ec2d.networkReachabilityCheckCache.Set(
 					target,

--- a/discoverers/discoverer_aws_ecs.go
+++ b/discoverers/discoverer_aws_ecs.go
@@ -195,7 +195,7 @@ func (ecsd *AwsEcsDiscoverer) processEcsListServicesPage(
 }
 
 func (ecsd *AwsEcsDiscoverer) processEcsService(
-	ctx context.Context,
+	_ context.Context,
 	service *types.Service,
 	result *discovery.Result,
 	awsAccountId string,

--- a/discoverers/discoverer_aws_rds.go
+++ b/discoverers/discoverer_aws_rds.go
@@ -2,7 +2,8 @@ package discoverers
 
 import (
 	"context"
-	"fmt"
+	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -269,7 +270,7 @@ func (rdsd *AwsRdsDiscoverer) reachabilityCheck(
 	}
 
 	for _, ip := range ips {
-		reachable := addressReachable(ctx, fmt.Sprintf("%s:%d", ip, port))
+		reachable := addressReachable(ctx, net.JoinHostPort(ip, strconv.Itoa(int(port))))
 		if reachable {
 			// set reachability to true in cache
 			rdsd.networkReachabilityCheckCache.Set(

--- a/discoverers/discoverer_docker.go
+++ b/discoverers/discoverer_docker.go
@@ -3,6 +3,8 @@ package discoverers
 import (
 	"context"
 	"fmt"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/borderzero/border0-go/lib/types/maps"
@@ -101,7 +103,7 @@ func (dd *DockerDiscoverer) Discover(ctx context.Context) *discovery.Result {
 		portBindings := map[string]string{}
 		for _, p := range container.Ports {
 			if p.IP != "" {
-				key := fmt.Sprintf("%s:%d", p.IP, p.PublicPort)
+				key := net.JoinHostPort(p.IP, strconv.Itoa(int(p.PublicPort)))
 				value := fmt.Sprintf("%d/%s", p.PrivatePort, p.Type)
 				portBindings[key] = value
 			}

--- a/discoverers/discoverer_network.go
+++ b/discoverers/discoverer_network.go
@@ -250,7 +250,7 @@ func checkService(ip string, port string) string {
 		}
 		req, _ := http.NewRequest(
 			http.MethodGet,
-			fmt.Sprintf("%s://%s:%s", scheme, ip, port),
+			fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(ip, port)),
 			nil,
 		)
 		resp, err := client.Do(req)
@@ -325,7 +325,7 @@ func checkService(ip string, port string) string {
 }
 
 func scanPort(ctx context.Context, ip, port string) (string, bool) {
-	if !addressReachable(ctx, fmt.Sprintf("%s:%s", ip, port)) {
+	if !addressReachable(ctx, net.JoinHostPort(ip, port)) {
 		return "", false
 	}
 


### PR DESCRIPTION
## [[ME-3242](https://mysocket.atlassian.net/browse/ME-3220)] Account for IPv6 Addresses Everywhere


[ME-3242]: https://mysocket.atlassian.net/browse/ME-3242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved network address construction using `net.JoinHostPort` for more robust and standardized handling across various discoverer modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->